### PR TITLE
Add DTE D1.11 rate schedule

### DIFF
--- a/d1.11.yaml
+++ b/d1.11.yaml
@@ -1,0 +1,24 @@
+template:
+  - sensor:
+      - name: "D1.11 Inflow"
+        unit_of_measurement: "USD/kWh"
+        device_class: monetary
+        state: >
+          {# Current rates found through the Michigan Public Service Commission's website,
+             https://www.michigan.gov/mpsc . These rates include:
+             * capacity charge
+             * non-capacity charge
+             * delivery charge
+             * Power Supply Cost Recovery (PSCR) charge, static since Nov 2023 but subject to change
+          #}
+          {% set month = now().month %}
+          {% set hour = now().hour %}
+          {% if hour < 15 or hour >= 19 %}
+            0.17859
+          {% else %}
+          {% if month in [10, 11, 12, 1, 2, 3, 4, 5] %}
+            0.1922
+          {% elif month in [6, 7, 8, 9] %}
+            0.23525
+          {% endif %}
+          {% endif %}


### PR DESCRIPTION
This PR adds the default D1.11 rate schedule from DTE, using the rates and fees published by the Michigan Public Service Commission's [latest rate sheet publishing from DTE](https://www.michigan.gov/mpsc/-/media/Project/Websites/mpsc/consumer/rate-books/electric/dte/dtee1curd1throughend.pdf?rev=6082f8fe73c1487bb4532d2e9d0510f9&hash=CE653D697A4A44943AFC6DC9A15D7484) ([archive.org for posterity](https://web.archive.org/web/20240715200935/https://www.michigan.gov/mpsc/-/media/Project/Websites/mpsc/consumer/rate-books/electric/dte/dtee1curd1throughend.pdf?rev=6082f8fe73c1487bb4532d2e9d0510f9&hash=CE653D697A4A44943AFC6DC9A15D7484).) These values include:
* capacity charge
* noncapacity charge
* delivery charge
* the [Power Supply Cost Recovery (PSCR) charge](https://www.michigan.gov/-/media/Project/Websites/mpsc/consumer/electric/pscr.pdf) ([archive.org](https://web.archive.org/web/20240716165622/https://www.michigan.gov/-/media/Project/Websites/mpsc/consumer/electric/pscr.pdf)), which can change depending on the price of electricity DTE purchases but hasn't since Nov 2023.

I'm using this PR on my own HomeAssistant instance and it functions as expected. Let me know if you'd rather see this without PSCR and I'll update.

Sidenote: it's really neat to find an old colleague's personal code out in the wild, doing cool stuff :grin: I hope this message finds you well!