### PR TITLE
 D1.11 rates: use off-peak rates on weekends

### DIFF
--- a/d1.11.yaml
+++ b/d1.11.yaml
@@ -12,8 +12,9 @@ template:
              * Power Supply Cost Recovery (PSCR) charge, static since Nov 2023 but subject to change
           #}
           {% set month = now().month %}
+          {% set day_of_week = now().isoweekday() %}
           {% set hour = now().hour %}
-          {% if hour < 15 or hour >= 19 %}
+          {% if hour < 15 or hour >= 19 or day_of_week in [6, 7] %}
             0.17859
           {% else %}
           {% if month in [10, 11, 12, 1, 2, 3, 4, 5] %}


### PR DESCRIPTION
This PR updates D1.11 rates to use off-peak rates on weekends. Resolves #3 